### PR TITLE
Combine uuid 14 and bcryptjs 3 updates and stabilize tests

### DIFF
--- a/__test__/api-airline-create.test.js
+++ b/__test__/api-airline-create.test.js
@@ -6,17 +6,17 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirlineModel } from '../src/models/airlineModel'
 
-describe('POST /api/v1/airline/', () => {
-  var airline = new AirlineModel({
-    name: 'Test Name',
-    icao: 'TEST',
-    country: 'Test Country',
-    id: '777',
-  })
+const airline = new AirlineModel({
+  name: testName('Test Airline'),
+  icao: testCode('TA'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
 
+describe('POST /api/v1/airline/', () => {
   describe('given a request with airline data', () => {
     const expected = { statusCode: 201, message: '' }
     let id

--- a/__test__/api-airline-delete.test.js
+++ b/__test__/api-airline-delete.test.js
@@ -6,18 +6,18 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirlineModel } from '../src/models/airlineModel'
+
+const airline = new AirlineModel({
+  name: testName('Test Airline'),
+  icao: testCode('TD'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
 
 describe('DELETE /api/v1/airline/{id}', () => {
   describe('given we pass a id as request param', () => {
-    var airline = new AirlineModel({
-      name: 'Test Name',
-      icao: 'TEST',
-      country: 'Test Country',
-      id: '777',
-    })
-
     beforeEach(async () => {
       await airline
         .save()

--- a/__test__/api-airline-list.test.js
+++ b/__test__/api-airline-list.test.js
@@ -6,24 +6,25 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirlineModel } from '../src/models/airlineModel'
+
+const airline1 = new AirlineModel({
+  name: testName('Initial Test Airline'),
+  icao: testCode('AL'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
+
+const airline2 = new AirlineModel({
+  name: testName('Updated Test Airline'),
+  icao: testCode('AL'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
 
 describe('GET /api/v1/airline/list', () => {
   describe('given country limit & offset as request params"', () => {
-    var airline1 = new AirlineModel({
-      name: 'Initial Test Name',
-      icao: 'INITIALTEST',
-      country: 'Test Country',
-      id: '777',
-    })
-    var airline2 = new AirlineModel({
-      name: 'Update Test Name',
-      icao: 'UPDATETEST',
-      country: 'Test Country',
-      id: '778',
-    })
-
     beforeEach(async () => {
       await airline1
         .save()

--- a/__test__/api-airline-listToAirport.test.js
+++ b/__test__/api-airline-listToAirport.test.js
@@ -1,32 +1,33 @@
 import { request, describe, test, expect, app } from './imports'
 
-import { delay } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirlineModel } from '../src/models/airlineModel'
 import { RouteModel } from '../src/models/routeModel'
 
+const destinationAirport = testCode('FAA')
+const airline1 = new AirlineModel({
+  name: testName('Initial Test Airline'),
+  icao: testCode('AT'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
+
+const airline2 = new AirlineModel({
+  name: testName('Updated Test Airline'),
+  icao: testCode('AT'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
+
+const route1 = new RouteModel({
+  airlineid: airline1.id,
+  destinationairport: destinationAirport,
+  sourceairport: testCode('SRC'),
+  airline: testName('Test Airline'),
+})
+
 describe('GET /api/v1/airline/list', () => {
   describe('given airport limit & offset as request params', () => {
-    var airline1 = new AirlineModel({
-      name: 'Initial Test Name',
-      icao: 'INITIALTEST',
-      country: 'Test Country',
-      id: '777',
-    })
-
-    var airline2 = new AirlineModel({
-      name: 'Update Test Name',
-      icao: 'UPDATETEST',
-      country: 'Test Country',
-      id: '778',
-    })
-
-    var route1 = new RouteModel({
-      airlineid: airline1.id,
-      destinationairport: 'FAA',
-      sourceairport: 'TESTSOURCE',
-      airline: 'TESTAIRLINE',
-    })
-
     beforeEach(async () => {
       await airline1
         .save()
@@ -57,7 +58,7 @@ describe('GET /api/v1/airline/list', () => {
       const response = await request(app).get(`/api/v1/airline/list`).query({
         offset: 0,
         limit: 5,
-        airport: 'FAA',
+        airport: destinationAirport,
       })
       expect(response.statusCode).toBe(200)
     })

--- a/__test__/api-airline-readByKey.test.js
+++ b/__test__/api-airline-readByKey.test.js
@@ -6,18 +6,18 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirlineModel } from '../src/models/airlineModel'
+
+const airline = new AirlineModel({
+  name: testName('Test Airline'),
+  icao: testCode('TR'),
+  country: 'Test Country',
+  id: testId('airline'),
+})
 
 describe('GET /api/v1/airline/{id}', () => {
   describe('given we pass a id as request param', () => {
-    var airline = new AirlineModel({
-      name: 'Test Name',
-      icao: 'TEST',
-      country: 'Test Country',
-      id: '777',
-    })
-
     beforeEach(async () => {
       await airline
         .save()

--- a/__test__/api-airline-update.test.js
+++ b/__test__/api-airline-update.test.js
@@ -6,24 +6,25 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirlineModel } from '../src/models/airlineModel'
+
+const airlineId = testId('airline')
+const initialAirline = new AirlineModel({
+  name: testName('Initial Test Airline'),
+  icao: testCode('AU'),
+  country: 'Initial Test Country',
+  id: airlineId,
+})
+const updatedAirline = new AirlineModel({
+  name: testName('Updated Test Airline'),
+  icao: testCode('AU'),
+  country: 'Update Test Country',
+  id: airlineId,
+})
 
 describe('PUT /api/v1/airline/', () => {
   describe('given the airline object is updated', () => {
-    var initialAirline = new AirlineModel({
-      name: 'Initial Test Name',
-      icao: 'INITIALTEST',
-      country: 'Initial Test Country',
-      id: '777',
-    })
-    var updatedAirline = new AirlineModel({
-      name: 'Update Test Name',
-      icao: 'UPDATETEST',
-      country: 'Update Test Country',
-      id: '777',
-    })
-
     beforeEach(async () => {
       await initialAirline
         .save()

--- a/__test__/api-airport-create.test.js
+++ b/__test__/api-airport-create.test.js
@@ -6,18 +6,18 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirportModel } from '../src/models/airportModel'
 
-describe('POST /api/v1/airport/', () => {
-  var airport = new AirportModel({
-    airportName: 'Test Name',
-    city: 'Test City',
-    country: 'Test Country',
-    id: '777',
-    faa: 'TESTFAA',
-  })
+const airport = new AirportModel({
+  airportName: testName('Test Airport'),
+  city: testName('Test City'),
+  country: 'Test Country',
+  id: testId('airport'),
+  faa: testCode('FAA'),
+})
 
+describe('POST /api/v1/airport/', () => {
   describe('given a request with airport data', () => {
     const expected = { statusCode: 201, message: '' }
     let id

--- a/__test__/api-airport-delete.test.js
+++ b/__test__/api-airport-delete.test.js
@@ -6,19 +6,19 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirportModel } from '../src/models/airportModel'
+
+const airport = new AirportModel({
+  airportName: testName('Test Airport'),
+  city: testName('Test City'),
+  country: 'Test Country',
+  id: testId('airport'),
+  faa: testCode('FAA'),
+})
 
 describe('DELETE /api/v1/airport/{id}', () => {
   describe('given we pass a id as request param', () => {
-    var airport = new AirportModel({
-      airportName: 'Test Name',
-      city: 'Test City',
-      country: 'Test Country',
-      id: '777',
-      faa: 'TESTFAA',
-    })
-
     beforeEach(async () => {
       await airport
         .save()

--- a/__test__/api-airport-get-direct-connections.test.js
+++ b/__test__/api-airport-get-direct-connections.test.js
@@ -6,27 +6,28 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirportModel } from '../src/models/airportModel'
 import { RouteModel } from '../src/models/routeModel'
 
+const airportCode = testCode('FAA')
+const airport = new AirportModel({
+  airportName: testName('Initial Test Airport'),
+  city: testName('Initial Test City'),
+  country: 'Initial Test Country',
+  id: testId('airport'),
+  faa: airportCode,
+})
+const route = new RouteModel({
+  airline: testName('Test Airline'),
+  airlineid: testId('airline'),
+  sourceairport: airportCode,
+  id: testId('route'),
+  destinationairport: testName('Destination Airport'),
+})
+
 describe('GET /api/v1/airport/direct-connections', () => {
   describe('given airport limit & offset as req params"', () => {
-    var airport = new AirportModel({
-      airportName: 'Initial Test Name',
-      city: 'Initial Test City',
-      country: 'Initial Test Country',
-      id: '777',
-      faa: 'TESTFAA',
-    })
-    var route = new RouteModel({
-      airline: 'Test Airline',
-      airlineid: 'Test AirlineId',
-      sourceairport: 'TESTFAA',
-      id: '777',
-      destinationairport: 'Test Destination Airport',
-    })
-
     beforeEach(async () => {
       await airport
         .save()
@@ -49,7 +50,7 @@ describe('GET /api/v1/airport/direct-connections', () => {
         .query({
           offset: 0,
           limit: 5,
-          airport: 'TESTFAA',
+          airport: airportCode,
         })
       expect(response.statusCode).toBe(200)
     }, 40000)

--- a/__test__/api-airport-list.test.js
+++ b/__test__/api-airport-list.test.js
@@ -6,26 +6,26 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirportModel } from '../src/models/airportModel'
+
+const airport1 = new AirportModel({
+  airportName: testName('Initial Test Airport'),
+  city: testName('Initial Test City'),
+  country: 'Test Country',
+  id: testId('airport'),
+  faa: testCode('FAA'),
+})
+const airport2 = new AirportModel({
+  airportName: testName('Updated Test Airport'),
+  city: testName('Updated Test City'),
+  country: 'Test Country',
+  id: testId('airport'),
+  faa: testCode('FAA'),
+})
 
 describe('GET /api/v1/airport/list', () => {
   describe('given country limit & offset as request params "', () => {
-    var airport1 = new AirportModel({
-      airportName: 'Initial Test Name',
-      city: 'Initial Test City',
-      country: 'Initial Test Country',
-      id: '777',
-      faa: 'TESTFAA',
-    })
-    var airport2 = new AirportModel({
-      airportName: 'Updated Test Name',
-      city: 'Updated Test City',
-      country: 'Updated Test Country',
-      id: '778',
-      faa: 'TESTFAA',
-    })
-
     beforeEach(async () => {
       await airport1
         .save()

--- a/__test__/api-airport-readByKey.test.js
+++ b/__test__/api-airport-readByKey.test.js
@@ -6,19 +6,19 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirportModel } from '../src/models/airportModel'
+
+const airport = new AirportModel({
+  airportName: testName('Test Airport'),
+  city: testName('Test City'),
+  country: 'Test Country',
+  id: testId('airport'),
+  faa: testCode('FAA'),
+})
 
 describe('GET /api/v1/airport/{id}', () => {
   describe('given we pass a id as request param', () => {
-    var airport = new AirportModel({
-      airportName: 'Test Name',
-      city: 'Test City',
-      country: 'Test Country',
-      id: '777',
-      faa: 'TESTFAA',
-    })
-
     beforeEach(async () => {
       await airport
         .save()

--- a/__test__/api-airport-update.test.js
+++ b/__test__/api-airport-update.test.js
@@ -6,26 +6,28 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { AirportModel } from '../src/models/airportModel'
+
+const airportId = testId('airport')
+const airportCode = testCode('FAA')
+const initialAirport = new AirportModel({
+  airportName: testName('Initial Test Airport'),
+  city: testName('Initial Test City'),
+  country: 'Initial Test Country',
+  id: airportId,
+  faa: airportCode,
+})
+const updatedAirport = new AirportModel({
+  airportName: testName('Updated Test Airport'),
+  city: testName('Updated Test City'),
+  country: 'Updated Test Country',
+  id: airportId,
+  faa: airportCode,
+})
 
 describe('PUT /api/v1/airport/', () => {
   describe('given the airport object is updated', () => {
-    var initialAirport = new AirportModel({
-      airportName: 'Initial Test Name',
-      city: 'Initial Test City',
-      country: 'Initial Test Country',
-      id: '777',
-      faa: 'TESTFAA',
-    })
-    var updatedAirport = new AirportModel({
-      airportName: 'Updated Test Name',
-      city: 'Updated Test City',
-      country: 'Updated Test Country',
-      id: '777',
-      faa: 'TESTFAA',
-    })
-
     beforeEach(async () => {
       await initialAirport
         .save()

--- a/__test__/api-route-create.test.js
+++ b/__test__/api-route-create.test.js
@@ -6,18 +6,18 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { RouteModel } from '../src/models/routeModel'
 
-describe('POST /api/v1/route/', () => {
-  var route = new RouteModel({
-    airline: 'Test Airline',
-    airlineid: 'Test AirlineId',
-    sourceairport: 'Test Airport',
-    id: '777',
-    destinationairport: 'TESTFAA',
-  })
+const route = new RouteModel({
+  airline: testName('Test Airline'),
+  airlineid: testId('airline'),
+  sourceairport: testName('Test Airport'),
+  id: testId('route'),
+  destinationairport: testCode('FAA'),
+})
 
+describe('POST /api/v1/route/', () => {
   describe('given a request with route data', () => {
     const expected = { statusCode: 201, message: '' }
     let id

--- a/__test__/api-route-delete.test.js
+++ b/__test__/api-route-delete.test.js
@@ -6,19 +6,19 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { RouteModel } from '../src/models/routeModel'
+
+const route = new RouteModel({
+  airline: testName('Test Airline'),
+  airlineid: testId('airline'),
+  sourceairport: testName('Test Airport'),
+  id: testId('route'),
+  destinationairport: testCode('FAA'),
+})
 
 describe('DELETE /api/v1/route/{id}', () => {
   describe('given we pass a id as request param', () => {
-    var route = new RouteModel({
-      airline: 'Test Airline',
-      airlineid: 'Test AirlineId',
-      sourceairport: 'Test Airport',
-      id: '777',
-      destinationairport: 'TESTFAA',
-    })
-
     beforeEach(async () => {
       await route
         .save()

--- a/__test__/api-route-readByKey.test.js
+++ b/__test__/api-route-readByKey.test.js
@@ -6,19 +6,19 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay, startInTest } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { RouteModel } from '../src/models/routeModel'
+
+const route = new RouteModel({
+  airline: testName('Test Airline'),
+  airlineid: testId('airline'),
+  sourceairport: testName('Test Airport'),
+  id: testId('route'),
+  destinationairport: testCode('FAA'),
+})
 
 describe('GET /api/v1/route/{id}', () => {
   describe('given we pass a id as request param', () => {
-    var route = new RouteModel({
-      airline: 'Test Airline',
-      airlineid: 'Test AirlineId',
-      sourceairport: 'Test Airport',
-      id: '777',
-      destinationairport: 'TESTFAA',
-    })
-
     beforeEach(async () => {
       await route
         .save()

--- a/__test__/api-route-update.test.js
+++ b/__test__/api-route-update.test.js
@@ -6,26 +6,27 @@ import {
   app, // REST application
 } from './imports'
 
-import { delay } from './testData'
+import { delay, testCode, testId, testName } from './testData'
 import { RouteModel } from '../src/models/routeModel'
+
+const routeId = testId('route')
+const initialRoute = new RouteModel({
+  airline: testName('Initial Test Airline'),
+  airlineid: testId('airline'),
+  sourceairport: testName('Initial Test Airport'),
+  id: routeId,
+  destinationairport: testCode('FAA'),
+})
+const updatedRoute = new RouteModel({
+  airline: testName('Updated Test Airline'),
+  airlineid: testId('airline'),
+  sourceairport: testName('Updated Test Airport'),
+  id: routeId,
+  destinationairport: testCode('FAA'),
+})
 
 describe('PUT /api/v1/route/', () => {
   describe('given the route object is updated', () => {
-    var initialRoute = new RouteModel({
-      airline: 'Initial Test Airline',
-      airlineid: 'Initial Test AirlineId',
-      sourceairport: 'Initial Test Airport',
-      id: '777',
-      destinationairport: 'TESTFAA',
-    })
-    var updatedRoute = new RouteModel({
-      airline: 'Updated Test Airline',
-      airlineid: 'Updated Test AirlineId',
-      sourceairport: 'Updated Test Airport',
-      id: '777',
-      destinationairport: 'TESTQAA',
-    })
-
     beforeEach(async () => {
       await initialRoute
         .save()

--- a/__test__/testData.js
+++ b/__test__/testData.js
@@ -21,8 +21,18 @@ const nextToken = () => `${runSeed}${(sequence++).toString(36).toUpperCase()}`
 
 export const testId = (prefix = 'test') => `${prefix}-${nextToken()}`
 
-export const testCode = (prefix = 'TEST') =>
-  `${prefix}${nextToken()}`.replace(/[^A-Z0-9]/g, '').slice(0, 16)
+export const testCode = (prefix = 'TEST') => {
+  const cleanPrefix = prefix
+    .replace(/[^A-Z0-9]/gi, '')
+    .toUpperCase()
+    .slice(0, 12)
+  const suffixLength = Math.max(1, 16 - cleanPrefix.length)
+  const suffix = nextToken()
+    .replace(/[^A-Z0-9]/g, '')
+    .slice(-suffixLength)
+
+  return `${cleanPrefix}${suffix}`.slice(0, 16)
+}
 
 export const testName = (prefix = 'Test') => `${prefix} ${nextToken()}`
 

--- a/__test__/testData.js
+++ b/__test__/testData.js
@@ -13,6 +13,19 @@ export const delay = (timems) =>
     }, timems)
   })
 
+const runSeed =
+  `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`.toUpperCase()
+let sequence = 0
+
+const nextToken = () => `${runSeed}${(sequence++).toString(36).toUpperCase()}`
+
+export const testId = (prefix = 'test') => `${prefix}-${nextToken()}`
+
+export const testCode = (prefix = 'TEST') =>
+  `${prefix}${nextToken()}`.replace(/[^A-Z0-9]/g, '').slice(0, 16)
+
+export const testName = (prefix = 'Test') => `${prefix} ${nextToken()}`
+
 export const startInTest = async () => {
   await ottoman.start()
   return true

--- a/__test__/testData.test.js
+++ b/__test__/testData.test.js
@@ -1,0 +1,13 @@
+import { testCode } from './testData'
+
+describe('testCode', () => {
+  it('keeps suffix entropy when the prefix is multiple characters long', () => {
+    const generated = Array.from({ length: 40 }, () => testCode('FAA'))
+
+    expect(new Set(generated).size).toBe(generated.length)
+    generated.forEach((value) => {
+      expect(value).toMatch(/^FAA[A-Z0-9]+$/)
+      expect(value.length).toBeLessThanOrEqual(16)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "axios": "^1.16.1",
-        "bcryptjs": "^2.4.3",
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "couchbase": "^4.7.0",
         "express": "^5.2.1",
@@ -3384,9 +3384,13 @@
       }
     },
     "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ottoman": "^2.5.6",
         "qs": "^6.15.2",
         "swagger-ui-express": "^4.6.3",
-        "uuid": "^11.1.1",
+        "uuid": "^14.0.0",
         "yamljs": "^0.3.0"
       },
       "devDependencies": {
@@ -9493,16 +9493,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.29.7",
     "axios": "^1.16.1",
-    "bcryptjs": "^2.4.3",
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "couchbase": "^4.7.0",
     "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ottoman": "^2.5.6",
     "qs": "^6.15.2",
     "swagger-ui-express": "^4.6.3",
-    "uuid": "^11.1.1",
+    "uuid": "^14.0.0",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- combine the pending `uuid` 14.0.0 and `bcryptjs` 3.0.3 Dependabot updates into one repo-owned branch
- stabilize the Jest integration suite by generating per-run unique test IDs/codes/names instead of reusing shared fixtures like `777`, `778`, and `TESTFAA`
- keep the dependency bumps intact while removing the shared-bucket data collisions that were tripping the CI `test` job

## Verification
- `npm run format`
- `set -a && source ./config/test.env && set +a && export APP_PORT=3112 && npx jest --verbose --runInBand`
- repeated with a second clean run on a different port to check for residual test-data collisions:
  - `set -a && source ./config/test.env && set +a && export APP_PORT=3113 && npx jest --verbose --runInBand`
- both local runs passed: 16 test suites, 16 tests

## Media evidence
- Retroactive reviewer-facing capture added on 2026-06-01 against this PR branch so the PR body now includes the same Swagger proof standard used for OttomanJS quickstart UI-facing maintenance.
- Captured the live Swagger surface plus a short walkthrough of four GET flows and the non-existent-route `404` check.

**Screenshot**

![Swagger UI manual verification](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1780350237/pr-evidence/couchbase-examples/ottomanjs-quickstart/pr-173/swagger-ui-overview-retro-2026-06-01.png)

**Video**
https://res.cloudinary.com/dhwqj0ps2/video/upload/v1780350237/pr-evidence/couchbase-examples/ottomanjs-quickstart/pr-173/swagger-manual-test-retro-2026-06-01.webm

<details><summary>Local artifacts</summary>

- `tutorial-maintenance/runs/ottomanjs-quickstart/2026-06-01-pr-173-retro-evidence/verification.md`
- `tutorial-maintenance/runs/ottomanjs-quickstart/2026-06-01-pr-173-retro-evidence/commands.txt`
- `tutorial-maintenance/runs/ottomanjs-quickstart/2026-06-01-pr-173-retro-evidence/screenshots/swagger-ui-overview.png`
- `tutorial-maintenance/runs/ottomanjs-quickstart/2026-06-01-pr-173-retro-evidence/video/swagger-manual-test.webm`

</details>

## Notes
- This PR supersedes Dependabot PRs #170 and #171 with one branch the repo can own.
- The dependency bumps themselves did not require application-code changes here; the failing path was the test suite's reuse of static IDs/codes against a shared Couchbase test bucket.
- I used non-default local ports because another local ottomanjs quickstart checkout was already bound to `3010`; that port conflict is local-only and not part of the repo change.

